### PR TITLE
Stubstotemplates

### DIFF
--- a/app/channels/submission_status_channel.rb
+++ b/app/channels/submission_status_channel.rb
@@ -15,6 +15,7 @@ class SubmissionStatusChannel < ApplicationCable::Channel
   def receive(data)
     return unless data['ping']
     SubmissionStatusChannel.broadcast_to("SubmissionStatus_user:_#{current_user.id}_exercise:_#{current_exercise.id}", JSON[message(current_exercise)])
+    SubmissionStatusChannel.broadcast_to("SubmissionStatus_user:_#{current_user.id}_exercise:_#{current_exercise.id}", JSON[message(current_exercise)])
   end
 
   def message(exercise)
@@ -22,7 +23,7 @@ class SubmissionStatusChannel < ApplicationCable::Channel
       message_generator('in progress', 'Yhteys tietokantaan ok, odotetaan', 0, false, exercise)
     elsif exercise.saved?
       message_generator('in progress', 'Tehtävä tallennettu tietokantaan', 0.1, false, exercise)
-    elsif exercise.testing_stub?
+    elsif exercise.testing_template?
       message_generator('in progress', 'Testataan tehtäväpohjaa', 0.3, false, exercise)
     elsif exercise.testing_model_solution?
       message_generator('in progress', 'Testataan malliratkaisua', 0.6, false, exercise)

--- a/app/controllers/api/v0/exercises/results_controller.rb
+++ b/app/controllers/api/v0/exercises/results_controller.rb
@@ -17,14 +17,14 @@ module Api
         private
 
         def package_type
-          params[:token].include?('MODEL') ? 'MODEL' : 'STUB'
+          params[:token].include?('MODEL') ? 'MODEL' : 'TEMPLATE'
         end
 
         def verify_secret_token(token, exercise)
           secret_token = if params[:token].include? 'MODEL'
                            token.gsub('MODEL', '')
                          else
-                           token.gsub('STUB', '')
+                           token.gsub('TEMPLATE', '')
                          end
 
           verifier = ActiveSupport::MessageVerifier.new(Rails.application.secrets[:secret_key_base])

--- a/app/controllers/api/v0/exercises/zips_controller.rb
+++ b/app/controllers/api/v0/exercises/zips_controller.rb
@@ -12,8 +12,8 @@ module Api
 
         def template
           exercise = Exercise.find(params[:exercise_id])
-          stub_filename = Dir.entries(exercise_target_path(exercise)).find { |o| o.start_with?('Stub') && o.end_with?('.zip') }
-          send_file template_zip_path(exercise, stub_filename)
+          template_filename = Dir.entries(exercise_target_path(exercise)).find { |o| o.start_with?('Template') && o.end_with?('.zip') }
+          send_file template_zip_path(exercise, template_filename)
         end
 
         private

--- a/app/controllers/api/v0/exercises_controller.rb
+++ b/app/controllers/api/v0/exercises_controller.rb
@@ -33,7 +33,7 @@ module Api
       def perform_jobs
         ExerciseVerifierJob.perform_later @exercise
         MessageBroadcasterJob.perform_now(@exercise)
-        TimeoutCheckerJob.set(wait: 1.minute).perform_later(@exercise)
+        TimeoutCheckerJob.set(wait: 2.minutes).perform_later(@exercise)
       end
 
       # Use callbacks to share common setup or constraints between actions.

--- a/app/jobs/exercise_verifier_job.rb
+++ b/app/jobs/exercise_verifier_job.rb
@@ -29,7 +29,7 @@ class ExerciseVerifierJob < ApplicationJob
 
   def exercise_modified?(exercise)
     if Dir.exist?(assignment_target_path(exercise)) && Dir.exist?(assignment_target_path(exercise).join("exercise_#{exercise.id}"))
-      if directory_includes_file(exercise, 'ModelSolution') || directory_includes_file(exercise, 'Stub')
+      if directory_includes_file(exercise, 'ModelSolution') || directory_includes_file(exercise, 'Template')
         return false
       end
     end
@@ -44,21 +44,21 @@ class ExerciseVerifierJob < ApplicationJob
     exercise.create_submission
 
     `cd #{tmp_submission_target_path(exercise).join('model').to_s} && tar -cpf #{packages_target_path.join("ModelSolutionPackage_#{exercise.id}.tar").to_s} *`
-    `cd #{tmp_submission_target_path(exercise).join('stub').to_s} && tar -cpf #{packages_target_path.join("StubPackage_#{exercise.id}.tar").to_s} *`
+    `cd #{tmp_submission_target_path(exercise).join('template').to_s} && tar -cpf #{packages_target_path.join("TemplatePackage_#{exercise.id}.tar").to_s} *`
   end
 
   def send_exercise_to_sandbox(exercise)
     create_tar_files(exercise)
 
-    # Send stub to sandbox
-    send_package_to_sandbox(exercise, 'STUB', "StubPackage_#{exercise.id}.tar")
+    # Send template to sandbox
+    send_package_to_sandbox(exercise, 'TEMPLATE', "TemplatePackage_#{exercise.id}.tar")
 
     # Send model solution to sandbox
     send_package_to_sandbox(exercise, 'MODEL', "ModelSolutionPackage_#{exercise.id}.tar")
   end
 
   def send_package_to_sandbox(exercise, package_type, package_name)
-    package_type == 'STUB' ? exercise.testing_stub! : exercise.testing_model_solution!
+    package_type == 'TEMPLATE' ? exercise.testing_template! : exercise.testing_model_solution!
 
     MessageBroadcasterJob.perform_now(exercise)
 

--- a/app/jobs/message_broadcaster_job.rb
+++ b/app/jobs/message_broadcaster_job.rb
@@ -13,7 +13,7 @@ class MessageBroadcasterJob < ApplicationJob
       message_generator('in progress', 'Yhteys tietokantaan ok, odotetaan', 0, false, exercise)
     elsif exercise.saved?
       message_generator('in progress', 'Tehtävä tallennettu tietokantaan', 0.1, false, exercise)
-    elsif exercise.testing_stub?
+    elsif exercise.testing_template?
       message_generator('in progress', 'Testataan tehtäväpohjaa', 0.3, false, exercise)
     elsif exercise.testing_model_solution?
       message_generator('in progress', 'Testataan malliratkaisua', 0.6, false, exercise)

--- a/lib/sandbox_results_handler.rb
+++ b/lib/sandbox_results_handler.rb
@@ -22,7 +22,7 @@ class SandboxResultsHandler
   end
 
   def set_status_and_passed_state(sandbox_status, test_output)
-    # Status will be 'finished' if both stub results and model solution results are finished in sandbox
+    # Status will be 'finished' if both template results and model solution results are finished in sandbox
     if @exercise.sandbox_results[:status] == '' || @exercise.sandbox_results[:status] == 'finished'
       @exercise.sandbox_results[:status] = sandbox_status
     end
@@ -42,7 +42,7 @@ class SandboxResultsHandler
 
   def compile_errors(test_output, package_type)
     return unless test_output['status'] == 'COMPILE_FAILED'
-    header = package_type == 'STUB' ? 'Tehtäväpohja ei kääntynyt: ' : 'Malliratkaisu ei kääntynyt: '
+    header = package_type == 'TEMPLATE' ? 'Tehtäväpohja ei kääntynyt: ' : 'Malliratkaisu ei kääntynyt: '
     messages = error_message_lines(test_output).join('\n')
     error = { header: header, messages: messages }
     @exercise.error_messages.push error
@@ -56,8 +56,8 @@ class SandboxResultsHandler
   def generate_message(sandbox_status, passed, compiled, package_type)
     if package_type == 'MODEL'
       model_message(sandbox_status, passed, compiled)
-    elsif package_type == 'STUB'
-      stub_message(sandbox_status, compiled)
+    elsif package_type == 'TEMPLATE'
+      template_message(sandbox_status, compiled)
     end
   end
 
@@ -70,9 +70,9 @@ class SandboxResultsHandler
                                            end
   end
 
-  def stub_message(sandbox_status, compiled)
+  def template_message(sandbox_status, compiled)
     @exercise.sandbox_results[:message] += ' Tehtäväpohjan tulokset: '
-    @exercise.sandbox_results[:stub_results_received] = true
+    @exercise.sandbox_results[:template_results_received] = true
     @exercise.sandbox_results[:message] += if sandbox_status == 'finished' && compiled then 'Kaikki OK.'
                                            else 'Koodi ei kääntynyt.'
                                            end

--- a/lib/sandbox_results_handler.rb
+++ b/lib/sandbox_results_handler.rb
@@ -35,7 +35,7 @@ class SandboxResultsHandler
     # Push test results into exercise's error messages
     return if test_output['testResults'].empty? || test_output['testResults'].first['successful']
     header = 'Virheet testeissä: '
-    messages = test_output['testResults'].join('\n')
+    messages = test_output['testResults'][0]['message']
     error = { header: header, messages: messages }
     @exercise.error_messages.push error
   end

--- a/lib/tmc_langs.rb
+++ b/lib/tmc_langs.rb
@@ -11,9 +11,9 @@ class TMCLangs
 --outputPath #{Rails.root.join('submission_generation', 'tmp', "Submission_#{exercise.id}", 'model')}`
   end
 
-  def self.prepare_stubs(exercise)
+  def self.prepare_templates(exercise)
     `java -jar #{langs_path.to_s} prepare-stubs --exercisePath #{Rails.root.join('submission_generation', 'tmp', "Submission_#{exercise.id}").to_s} \
---outputPath #{Rails.root.join('submission_generation', 'tmp', "Submission_#{exercise.id}", 'stub')}`
+--outputPath #{Rails.root.join('submission_generation', 'tmp', "Submission_#{exercise.id}", 'template')}`
   end
 
   private_class_method

--- a/lib/zip_handler.rb
+++ b/lib/zip_handler.rb
@@ -20,7 +20,7 @@ class ZipHandler
   def update_model_and_template
     model_file = File.open(submission_target_path.join('model', 'src', 'Submission.java').to_s, 'rb:UTF-8')
     model = model_file.read
-    template_file = File.open(submission_target_path.join('stub', 'src', 'Submission.java').to_s, 'rb:UTF-8')
+    template_file = File.open(submission_target_path.join('template', 'src', 'Submission.java').to_s, 'rb:UTF-8')
     template = template_file.read
     model_file.close
     template_file.close
@@ -33,16 +33,16 @@ class ZipHandler
   end
 
   def create_zips
-    create_zip(exercise_target_path.join("Stub_#{@exercise.id}.#{@exercise.versions.last.id}.zip").to_s, 'stub')
+    create_zip(exercise_target_path.join("Template_#{@exercise.id}.#{@exercise.versions.last.id}.zip").to_s, 'template')
     create_zip(exercise_target_path.join("ModelSolution_#{@exercise.id}.#{@exercise.versions.last.id}.zip").to_s, 'model')
   end
 
   def retire_zips
-    stub_file = search_zip_file('Stub')
+    template_file = search_zip_file('Template')
     model_file = search_zip_file('ModelSolution')
 
-    unless stub_file.nil?
-      FileUtils.mv exercise_target_path.join(stub_file), exercise_target_path.join('oldies')
+    unless template_file.nil?
+      FileUtils.mv exercise_target_path.join(template_file), exercise_target_path.join('oldies')
     end
 
     return if model_file.nil?

--- a/spec/integration/api/v0/exercises/zips_controller_spec.rb
+++ b/spec/integration/api/v0/exercises/zips_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V0::Exercises::ZipsController, type: :request do
       'submission_generation', 'packages', "assignment_#{exercise.assignment_id}", "exercise_#{exercise.id}", "ModelSolution_#{exercise.id}.1.zip"
     ).to_s)
     FileUtils.touch(Rails.root.join(
-      'submission_generation', 'packages', "assignment_#{exercise.assignment_id}", "exercise_#{exercise.id}", "Stub_#{exercise.id}.1.zip"
+      'submission_generation', 'packages', "assignment_#{exercise.assignment_id}", "exercise_#{exercise.id}", "Template_#{exercise.id}.1.zip"
     ).to_s)
 
     get "/api/v0/exercises/#{exercise.id}/model_solution.zip"

--- a/spec/jobs/exercise_verifier_job_spec.rb
+++ b/spec/jobs/exercise_verifier_job_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe ExerciseVerifierJob, type: :job do
 
     it 'sends exercise to backend' do
       exercise.sandbox_results = { status: '', message: '', passed: false,
-                                   model_results_received: false, stub_results_received: false }
+                                   model_results_received: false, template_results_received: false }
 
       ExerciseVerifierJob.perform_now(exercise)
       expect(exercise.status).to eq('testing_model_solution')
 
       FileUtils.remove_dir("submission_generation/tmp/Submission_#{exercise.id}")
       FileUtils.remove_entry("submission_generation/packages/ModelSolutionPackage_#{exercise.id}.tar")
-      FileUtils.remove_entry("submission_generation/packages/StubPackage_#{exercise.id}.tar")
+      FileUtils.remove_entry("submission_generation/packages/TemplatePackage_#{exercise.id}.tar")
     end
   end
 end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe Exercise, type: :model do
       exercise.create_submission
 
       directory = Dir.new("submission_generation/tmp/Submission_#{exercise.id}")
-      expect(directory.entries).to include('model', 'stub')
+      expect(directory.entries).to include('model', 'template')
 
       FileUtils.remove_dir("submission_generation/tmp/Submission_#{exercise.id}")
     end
   end
 
   describe 'when receiving results from sandbox' do
-    context 'when stub does not compile and tests fail' do
+    context 'when template does not compile and tests fail' do
       it 'handles sandbox results properly' do
         exercise.code =
           'System.out.println("moi");
@@ -37,7 +37,7 @@ RSpec.describe Exercise, type: :model do
            return "Hello " + input;
            // END SOLUTION'
         exercise.sandbox_results = { status: '', message: '', passed: false,
-                                     model_results_received: false, stub_results_received: false }
+                                     model_results_received: false, template_results_received: false }
 
         # Handle model solutions results
         exercise.handle_results('finished', { 'status' => 'TESTS_FAILED',
@@ -46,9 +46,9 @@ RSpec.describe Exercise, type: :model do
                                                                   'valgrindFailed' => false, 'points' => ['01-11'],
                                                                   'exception' => ['expected:<Hello[lolled]> but was: <Hello [lol]>'] }],
                                               'logs' => { 'stdout' => [109, 111, 105, 10], 'stderr' => [] } }, 'MODEL')
-        # Handle stubs results
+        # Handle template's results
         exercise.handle_results('finished', { 'status' => 'COMPILE_FAILED', 'testResults' => [],
-                                              'logs' => { 'stdout' => StdoutExample.new.example, 'stderr' => [] } }, 'STUB')
+                                              'logs' => { 'stdout' => StdoutExample.new.example, 'stderr' => [] } }, 'TEMPLATE')
 
         expect(exercise.sandbox_results[:passed]).to be(false)
         expect(exercise.sandbox_results[:status]).not_to be('finished')
@@ -65,7 +65,7 @@ RSpec.describe Exercise, type: :model do
       ZipHandler.new(exercise).clean_up
 
       expect(File).to exist(exercise_target_path.join("ModelSolution_#{exercise.id}.#{exercise.versions.last.id}.zip"))
-      expect(File).to exist(exercise_target_path.join("Stub_#{exercise.id}.#{exercise.versions.last.id}.zip"))
+      expect(File).to exist(exercise_target_path.join("Template_#{exercise.id}.#{exercise.versions.last.id}.zip"))
 
       FileUtils.remove_dir("submission_generation/packages/assignment_#{exercise.assignment.id}/")
     end


### PR DESCRIPTION
'Stub' was apparently a bad name for exercise templates now the code is refactored to use 'template' instead.
plus some bug fixes.

 :put_litter_in_its_place: