### PR TITLE
Fix error messages

### DIFF
--- a/app/controllers/api/v0/exercises/results_controller.rb
+++ b/app/controllers/api/v0/exercises/results_controller.rb
@@ -11,11 +11,7 @@ module Api
 
           return if exercise.finished? || exercise.error? || !submit_count_correct(token, exercise)
 
-          exercise.error_messages.each do |error|
-            if error['header'].include?('Tehtäväntarkastuspalvelin vastasi liian hitaasti')
-              exercise.error_messages = []
-            end
-          end
+          exercise.error_messages = [] if exercise.error_messages.any? { |error| error['header'].include?('Tehtäväntarkastuspalvelin vastasi liian hitaasti') }
 
           TarballRemoverJob.perform_later(package_type(token), exercise)
 

--- a/app/controllers/api/v0/exercises/results_controller.rb
+++ b/app/controllers/api/v0/exercises/results_controller.rb
@@ -11,7 +11,11 @@ module Api
 
           return if exercise.finished? || exercise.error? || !submit_count_correct(token, exercise)
 
-          exercise.error_messages = []
+          exercise.error_messages.each do |error|
+            if error['header'].include?('Tehtäväntarkastuspalvelin vastasi liian hitaasti')
+              exercise.error_messages = []
+            end
+          end
 
           TarballRemoverJob.perform_later(package_type(token), exercise)
 

--- a/app/jobs/timeout_checker_job.rb
+++ b/app/jobs/timeout_checker_job.rb
@@ -11,7 +11,7 @@ class TimeoutCheckerJob < ApplicationJob
   # Timeout happens if exercise results are not received fast enough
   def perform(exercise)
     return if exercise.finished? || exercise.error?
-    exercise.error_messages.push(header: 'Emme onnistuneet käsittelemään tehtävääsi, anteeksi', messages: '')
+    exercise.error_messages.push(header: 'Tehtäväntarkastuspalvelin vastasi liian hitaasti, yritä tehtävän lähetystä uudelleen', messages: '')
     exercise.sandbox_timeout!
     MessageBroadcasterJob.perform_now(exercise)
   end


### PR DESCRIPTION
Make error messages clearer.
Move activating TimeoutCheckerJob to a different place in SandboxPosterJob.
 :snake: :camel: :camel: :camel: 